### PR TITLE
Fixed sbt clean update package-dist failure on missing ostrich version

### DIFF
--- a/project/build/NaggatiProject.scala
+++ b/project/build/NaggatiProject.scala
@@ -3,7 +3,7 @@ import com.twitter.sbt._
 
 class NaggatiProject(info: ProjectInfo) extends StandardProject(info) with DefaultRepos {
   val netty = "org.jboss.netty" % "netty" % "3.2.3.Final"
-  val ostrich = "com.twitter" % "ostrich" % "3.0.0-SNAPSHOT"
+  val ostrich = "com.twitter" % "ostrich" % "3.0.4"
 
   // scala actors library with fork-join replaced by java 5 util.concurrent:
   // FIXME: we should investigate akka actors.


### PR DESCRIPTION
Before this commit, `sbt clean update package-dist` produces the following error (on OS X 10.6 and Scala 2.8.1 installed via homebrew):

```
[warn]  ==== Scala-Tools Maven2 Repository: tried
[warn]    http://scala-tools.org/repo-releases/com/twitter/ostrich/3.0.0-SNAPSHOT/ostrich-3.0.0-SNAPSHOT.pom
[warn]    -- artifact com.twitter#ostrich;3.0.0-SNAPSHOT!ostrich.jar:
[warn]    http://scala-tools.org/repo-releases/com/twitter/ostrich/3.0.0-SNAPSHOT/ostrich-3.0.0-SNAPSHOT.jar
[warn]          ::::::::::::::::::::::::::::::::::::::::::::::
[warn]          ::          UNRESOLVED DEPENDENCIES         ::
[warn]          ::::::::::::::::::::::::::::::::::::::::::::::
[warn]          :: com.twitter#ostrich;3.0.0-SNAPSHOT: not found
[warn]          ::::::::::::::::::::::::::::::::::::::::::::::
[info] 
[info] :: USE VERBOSE OR DEBUG MESSAGE LEVEL FOR MORE DETAILS
[error] sbt.ResolveException: unresolved dependency: com.twitter#ostrich;3.0.0-SNAPSHOT: not found
```

There is no `3.0.0-SNAPSHOT` at http://maven.twttr.com/com/twitter/ostrich/, so I updated `project/build/NaggatiProject.scala` to use `3.0.4` instead.  It builds cleanly and all tests pass after the change.
