### PR TITLE
use ByteBuffer instead of Array[Byte] for MemcacheCodec

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+3.0.0
+-----
+release: 1 March 2012
+
+- Switch MemcacheRequest and MemcacheResponse to use ByteBuffer instead of Array[Byte]
+
 2.2.2
 -----
 release: 9 February 2012

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,9 +1,9 @@
 #Project properties
-#Thu Feb 09 16:45:07 PST 2012
+#Thu Mar 01 13:23:46 PST 2012
 project.organization=com.twitter
 project.name=naggati
 sbt.version=0.7.4
-project.version=2.2.3-SNAPSHOT
+project.version=3.0.0-SNAPSHOT
 def.scala.version=2.7.7
 build.scala.versions=2.8.1
 project.initialize=false

--- a/src/main/scala/com/twitter/naggati/codec/MemcacheCodec.scala
+++ b/src/main/scala/com/twitter/naggati/codec/MemcacheCodec.scala
@@ -19,26 +19,27 @@ package codec
 
 import com.twitter.concurrent
 import com.twitter.util.Future
+import java.nio.ByteBuffer
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import org.jboss.netty.channel.{Channel, Channels}
 
-case class MemcacheRequest(line: List[String], data: Option[Array[Byte]], bytesRead: Int) {
+case class MemcacheRequest(line: List[String], data: Option[ByteBuffer], bytesRead: Int) {
   override def toString = {
     "<Request: " + line.mkString("[", " ", "]") + (data match {
       case None => ""
-      case Some(x) => " data=" + x.size
+      case Some(x) => " data=" + x.remaining
     }) + " read=" + bytesRead + ">"
   }
 }
 
 case class MemcacheResponse(
   line: String,
-  data: Option[Array[Byte]] = None
+  data: Option[ByteBuffer] = None
 ) extends Codec.Signalling {
   override def toString = {
     "<Response: " + line + (data match {
       case None => ""
-      case Some(x) => " data=" + x.size
+      case Some(x) => " data=" + x.remaining
     }) + ">"
   }
 
@@ -46,7 +47,7 @@ case class MemcacheResponse(
 
   def writeAscii(): Option[ChannelBuffer] = {
     if (lineData.size > 0) {
-      val dataSize = if (data.isDefined) (data.get.size + MemcacheCodec.END.size) else 0
+      val dataSize = if (data.isDefined) (data.get.remaining + MemcacheCodec.END.size) else 0
       val size = lineData.size + MemcacheCodec.CRLF.size + dataSize
       val buffer = ChannelBuffers.buffer(size)
       buffer.writeBytes(lineData)
@@ -86,8 +87,9 @@ object MemcacheCodec {
       val dataBytes = segments(4).toInt
       ensureBytes(dataBytes + 2) { buffer =>
         // final 2 bytes are just "\r\n" mandated by protocol.
-        val bytes = new Array[Byte](dataBytes)
+        val bytes = ByteBuffer.allocate(dataBytes)
         buffer.readBytes(bytes)
+        bytes.flip()
         buffer.skipBytes(2)
         emit(MemcacheRequest(segments.toList, Some(bytes), line.length + dataBytes + 4))
       }

--- a/src/test/scala/com/twitter/naggati/codec/MemcacheCodecSpec.scala
+++ b/src/test/scala/com/twitter/naggati/codec/MemcacheCodecSpec.scala
@@ -18,6 +18,7 @@ package com.twitter.naggati
 package codec
 
 import com.twitter.util.Future
+import java.nio.ByteBuffer
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import org.jboss.netty.channel.Channel
 import org.specs.Specification
@@ -77,7 +78,7 @@ class MemcacheCodecSpec extends Specification with JMocker {
     "write data response" in {
       val (codec, counter) = TestCodec(MemcacheCodec.readAscii, MemcacheCodec.writeAscii)
 
-      codec.send(new MemcacheResponse("VALUE foo 0 5", Some("hello".getBytes))) mustEqual
+      codec.send(new MemcacheResponse("VALUE foo 0 5", Some(ByteBuffer.wrap("hello".getBytes)))) mustEqual
         List("VALUE foo 0 5\r\nhello\r\nEND\r\n")
     }
 
@@ -100,7 +101,7 @@ class MemcacheCodecSpec extends Specification with JMocker {
 
       codec.send(new MemcacheResponse("OK") then Codec.Stream(channel)) mustEqual List("OK\r\n")
 
-      Future.join(channel.send(new MemcacheResponse("VALUE foo 0 5", Some("kitty".getBytes))))()
+      Future.join(channel.send(new MemcacheResponse("VALUE foo 0 5", Some(ByteBuffer.wrap("kitty".getBytes)))))()
       codec.getDownstream mustEqual List("OK\r\n", "VALUE foo 0 5\r\nkitty\r\nEND\r\n")
 
       Future.join(channel.send(new MemcacheResponse("END")))()


### PR DESCRIPTION
- use ByteBuffer instead of Array[Byte] for MemcacheCodec
- bump to 3.0.0 since this is an API change
